### PR TITLE
Fix Thaumcraft crash and some issues related to Gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,9 @@ dependencies {
     deobfCompile "team.chisel.ctm:CTM:MC1.12+"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.690"
-    deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Mod-JEI:1.12-4.1.20.690"
+    deobfCompile ("CraftTweaker2:CraftTweaker2-MC1120-Mod-JEI:1.12-4.1.20.690") {
+        transitive = false
+    }
 
     if (!project.hasProperty("singleproject")) {
         deobfCompile "betterwithmods.core:BetterWithLib:1.12-1.5"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "BetterWithMods"

--- a/src/main/java/betterwithmods/module/compat/thaumcraft/Thaumcraft.java
+++ b/src/main/java/betterwithmods/module/compat/thaumcraft/Thaumcraft.java
@@ -73,7 +73,7 @@ public class Thaumcraft extends CompatFeature {
             AspectList tmp = null;
             //TODO temp disable this until I actually decide to fix it
 
-            Method method = ObfuscationReflectionHelper.findMethod(ThaumcraftCraftingManager.class, "getAspectsFromIngredients", AspectList.class, ItemStack.class, IRecipe.class, ArrayList.class);
+            Method method = ObfuscationReflectionHelper.findMethod(ThaumcraftCraftingManager.class, "getAspectsFromIngredients", AspectList.class, NonNullList.class, ItemStack.class, IRecipe.class, ArrayList.class);
             method.setAccessible(true);
 
             try {


### PR DESCRIPTION
- Fix Thaumcraft crash that happens because of reflection.
- Make Crafttweaker JEI modules dependencies transitive so it won't create errors while setting up the workspace
- Add settings.gradle. It makes gradle work a bit faster and it's encouraged to always have it.

Additionally you should remove runtime dependency of MCMultipart and use the runClient task instead of generated Intellij run tasks because generated run tasks are bullshit